### PR TITLE
bump biome version to 2.4.13 in code quality workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.4.12
+          version: 2.4.13
       - name: Run Biome
         run: biome ci .


### PR DESCRIPTION
This is the same version we are using in package.json